### PR TITLE
rename column and add slug column

### DIFF
--- a/database/migrations/20190819082345-add-slug-filed-to-events-table.js
+++ b/database/migrations/20190819082345-add-slug-filed-to-events-table.js
@@ -1,0 +1,9 @@
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    queryInterface.addColumn('events', 'slug', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    }),
+
+  down: queryInterface => queryInterface.removeColumn('events', 'slug'),
+}

--- a/database/migrations/20190819145346-change-name-column-to-title.js
+++ b/database/migrations/20190819145346-change-name-column-to-title.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('events', 'name', 'title')
+    await queryInterface.changeColumn('events', 'title', {
+      type: Sequelize.STRING,
+      unique: false,
+      allowNull: false,
+    })
+  },
+
+  down: queryInterface =>
+    queryInterface.renameColumn('events', 'title', 'name'),
+}

--- a/database/models/Event.js
+++ b/database/models/Event.js
@@ -9,9 +9,13 @@ module.exports = class Event extends Sequelize.Model {
           unique: true,
           primaryKey: true,
         },
-        name: {
+        title: {
           type: Sequelize.STRING,
-          unique: true,
+          unique: false,
+        },
+        slug: {
+          type: Sequelize.STRING,
+          allowNull: false,
         },
         location: {
           type: Sequelize.STRING,


### PR DESCRIPTION
#### What does this PR do?
It solves this issue #27  

#### Description of Task to be completed?
Write migrations to :-

1. Change column name `name` to `title`.
2. Add `slug` column to events table.

#### How should this be manually tested?
Pull the changes and run `yarn db:migrate` . 
Go view the events table, the above changes should reflect.

#### Any background context you want to provide?
`slug` will be used in URL(frontend)  when viewing a specific event.
#### What are the relevant tasks or issues?
#27 

