### PR TITLE
Add docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:9-slim
+WORKDIR /app
+COPY package.json /app
+RUN npm install
+COPY . /app
+CMD ["npm", "start"]
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,30 @@ Then run the command below to start the application in development mode
 
 `yarn start:dev`
 
+**Run with Docker**
+
+You should have docker install in your machine. If you have docker set up go
+ahead and spin the server by:
+
+* Build the image
+
+    `docker build -t swahilibox-events-api-docker .`
+
+* Run docker image
+
+    `docker run -it -p 9000:5000 swahilibox-events-api-docker `
+
+    NOTE: `5000` is the port at which the app is running.
+
+* To docker in the background
+
+    `docker run -d -p 9000:5000 swahilibox-events-api-docker`
+
+* Access the API on port `9000`
+
+     `http://localhost:9000/`
+
+
 ### Switch to the master branch for stable/working features
 
 `git checkout master`


### PR DESCRIPTION
#### What does this PR do?

Dockerize the application.

#### Description of Task to be completed?

Set up the application's docker image to offer a virtual environment or platform to manage the application packages in one environment and ship it as one package.  

#### How should this be manually tested?

Make sure you have docker installed in your machine.

* Pull this branch `ch-set-up-docker-image` and checkout to it.

* Build the image

    `docker build -t swahilibox-events-api-docker .`

* If successful, run the docker image

    `docker run -it -p 9000:5000 swahilibox-events-api-docker `

* Access the app on port `9000`



#### Any background context you want to provide?

#### What are the relevant tasks or issues?
 
Relevant [Issue](https://github.com/SwahiliBox/swahilibox-events-api/issues/29).

#### Screenshots (if appropriate)

#### Questions:
