### PR TITLE
Bg: Add database password variable to the .env-cmdrc-sample file

### DIFF
--- a/.env-cmdrc.sample
+++ b/.env-cmdrc.sample
@@ -5,6 +5,7 @@
     "DATABASE_DIALECT": "postgres",
     "HOST": "127.0.0.1",
     "DATABASE_USER": "database-username",
+    "DATABASE_PASSWORD": "database-password",
     "NODE_ENV": "development",
     "SECRET_KEY": "some-really-secret-key",
     "JWT_EXPIRATION": "5d" // smaple valid values 60, 2 days, 10h, 5d
@@ -15,6 +16,7 @@
     "DATABASE_DIALECT": "postgres",
     "HOST": "127.0.0.1",
     "DATABASE_USER": "database-username",
+    "DATABASE_PASSWORD": "database-password",
     "NODE_ENV": "test",
     "SECRET_KEY": "some-really-secret-key",
     "JWT_EXPIRATION": "5d" // smaple valid values 60, 2 days, 10h, 5d


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes issue #47  which aims at adding the database password variable to the `.env-cmdrc-sample` file.

#### Description of Task to be completed?
Add `DATABASE_PASSWORD` to `.env-cmd-sample` file for both development and test environments.


